### PR TITLE
Add loop to persist tasks on card

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,8 +31,6 @@ function createNewTask(item, complete) {
   task.addNewTask(task);
   taskInput.value = '';
   enableAndDisableButtons();
-  // task.saveTaskToStorage(tasks);
-
 }
 
 // COLLECTS TITLE INFO FROM FORM AND BEGINS PROCESS OF
@@ -53,6 +51,7 @@ function makeList(title, tasks, urgent) {
   clearInputField();
   enableAndDisableButtons();
   list.saveToStorage(lists);
+  // tasks.splice(0, tasks.length);
   // console.log(event.target.parentNode.firstElementChild.firstElementChild.nextElementSibling.nextElementSibling.firstElementChild.id)
 }
 
@@ -61,32 +60,22 @@ function pageLoad() {
   if ('list' in localStorage) {
     checkLocalStorage();
   }
-  // if ('task' in localStorage) {
-  //   parseTaskLocalStorage();
-  // }
 }
 
 // GETS KEY:LIST FROM LOCALSTORAGE AND TAKES IT OUT OF STRING
-function parseListLocalStorage() {
+function parseLocalStorage() {
   var getListItem = localStorage.getItem('list');
-  var storedListArray = JSON.parse(getListItem);
-  return storedListArray;
+  var storedArray = JSON.parse(getListItem);
+  return storedArray;
 }
-
-// function parseTaskLocalStorage() {
-//   var getTaskItem = localStorage.getItem('task');
-//   var storedTaskArray = JSON.parse(getTaskItem);
-//   for (var i = 0; i < storedTaskArray.length; i++) {
-//     createNewTask(storedTaskArray[i].item, storedTaskArray[i].complete);
-//   }
-// }
 
 // LOOPS THROUGH ARRAY OF TODO LISTS IN LOCALSTORAGE AND
 // MAKES A CARD WITH THE STORED PROPERTIES
 function checkLocalStorage() {
-  var storedListArray = parseListLocalStorage();
-  for (var i = 0; i < storedListArray.length; i++) {
-    makeList(storedListArray[i].title, storedListArray[i].tasks, storedListArray[i].urgent);
+  var storedArray = parseLocalStorage();
+  for (var i = 0; i < storedArray.length; i++) {
+    storedArray[i].tasks.forEach(t => tasks.push(t));
+    makeList(storedArray[i].title, storedArray[i].tasks, storedArray[i].urgent);
   }
 }
 
@@ -117,7 +106,7 @@ function removeList() {
   var i = lists.indexOf(listToRemove);
   if (event.target.className === 'img-btn') {
     lists.splice(i, 1);
-    event.target.closest('.card').remove();
+    event.target.classList.contains('.card').remove();
     listToRemove.saveToStorage(lists);
     tasks.splice(0, tasks.length);
     noListMsg.classList.remove('hidden');
@@ -143,7 +132,6 @@ function removeAllTasksFromArray() {
       tasks.splice(0, tasks.length);
   }
 }
-
 
 // REMOVES EMPTY CONTAINER WHERE TASKS ARE ADDED ON THE
 // PAGE, IF NO TASKS ARE ADDED ON THE FORM
@@ -186,7 +174,6 @@ function clearInputField() {
   var inputField = document.querySelector('form');
   inputField.reset();
 }
-
 
 function addTasksToList() {
   var checklistHTML;

--- a/styles.css
+++ b/styles.css
@@ -165,14 +165,12 @@ form {
 #title-input {
   border-radius: 4px;
   margin-bottom: 9%;
-  /* height: 26.15%; */
   width: 92%;
 }
 
 .task-input-wrapper {
   align-items: center;
   display: flex;
-  /* height: 26.15%; */
   justify-content: center;
   margin-top: 1%;
   width: 100%;
@@ -205,6 +203,7 @@ button,
 }
 
 button:hover,
+.img-btn:hover,
 /* .img-wrapper:hover, */
 .img-btn:hover,
 /* .checkbox-img-wrapper:hover, */

--- a/task.js
+++ b/task.js
@@ -5,10 +5,6 @@ class Task {
     this.completed = complete;
   }
 
-  // saveTaskToStorage() {
-  //   localStorage.setItem('task', JSON.stringify(tasks));
-  // }
-
   addNewTask(newTask) {
     taskHolder.classList.remove('hidden');
     taskHolder.insertAdjacentHTML('beforeend', `


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling- no new features

### Detailed Description
Added a forEach arrow function to pull in the tasks item property on each iteration of the for loop running through the lists array. This allows the tasks to persist when the page is reloaded.
### Why is this change required? What problem does it solve?
So the tasks persist.

### Files modified:
- [ ] index.html
- [ ] styles.css
- [x] main.js
- [ ] todo-list.js
- [ ] task.js
